### PR TITLE
`--tables` option crashes

### DIFF
--- a/postgresql_sequence_utils/utils.py
+++ b/postgresql_sequence_utils/utils.py
@@ -12,8 +12,10 @@ def get_broken_sequence_info(sequence_info):
             info[table] = table_info
     return info
 
+
 def parse_table_names(value):
-    return map(lambda v: v.strip, value.split(','))
+    return [v.strip() for v in value.split(',')]
+
 
 def validate_options(options):
     """raises :class:`CommandError` when options are invalid"""


### PR DESCRIPTION
The `--tables` option crashes with

```
Traceback (most recent call last):
  File "django/core/management/base.py", line 222, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "django/core/management/base.py", line 252, in execute
    output = self.handle(*args, **options)
  File "postgresql_sequence_utils/management/commands/postgresql_fix_sequences.py", line 60, in handle
    validate_options(options)
  File "postgresql_sequence_utils/utils.py", line 33, in validate_options
    if ';' in table:
TypeError: argument of type 'builtin_function_or_method' is not iterable
TypeError: argument of type 'builtin_function_or_method' is not iterable
```
